### PR TITLE
Fixed issue where redis docker container would not run

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -100,8 +100,11 @@ Vagrant.configure("2") do |config|
   # Add Redis docker container
   config.vm.provision "docker" do |d|
     d.pull_images "redis:alpine"
-    d.run "redis:alpine",
-      args: "--restart=always -d --name redis -h redis -p 6379:6379 -v /var/lib/redis/data:/data"
+    d.run "redis",
+      image: "redis:alpine",
+      args: "-h redis -p 6379:6379 -v /var/lib/redis/data:/data",
+      restart: "always",
+      daemonize: true
   end
 
 


### PR DESCRIPTION
While running Redis, Vagrant would crash with the following error:

```C:/HashiCorp/Vagrant/embedded/gems/2.2.5/gems/vagrant-2.2.5/plugins/provisioners/docker/client.rb:134:in `initialize': Invalid argument @ rb_sysopen - .../.vagrant/machines/default/virtualbox/docker-redis:alpine (Errno::EINVAL)
        from C:/HashiCorp/Vagrant/embedded/gems/2.2.5/gems/vagrant-2.2.5/plugins/provisioners/docker/client.rb:134:in `open'```

This PR fixes that error by specifying the name of the container as the first argument to `d.run`